### PR TITLE
Updated pom.xml with usable dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,65 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>us.elephanthunter</groupId>
+	<artifactId>Wiki7ZipXmlDumpReader</artifactId>
+	<version>0.0.1</version>
+	<packaging>jar</packaging>
+
+	<name>Wiki7ZipXmlDumpReader</name>
+	<url>https://github.com/leebradley/wikiedit-monitor</url>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<scm>
+		<url>https://github.com/leebradley/wikiedit-monitor</url>
+		<connection>https://github.com/leebradley/wikiedit-monitor.git</connection>
+		<developerConnection>scm:git:git@github.com:leebradley/wikiedit-monitor.git</developerConnection>
+	</scm>
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-compress</artifactId>
+			<version>1.12</version>
+		</dependency>
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>copy-dependencies</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>copy-dependencies</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${project.build.directory}/lib</outputDirectory>
+							<overWriteReleases>false</overWriteReleases>
+							<overWriteSnapshots>false</overWriteSnapshots>
+							<overWriteIfNewer>true</overWriteIfNewer>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifest>
+							<addClasspath>true</addClasspath>
+							<classpathPrefix>lib/</classpathPrefix>
+							<mainClass>us.elephanthunter.Wiki7ZipXmlDumpReader.Wiki7ZipXmlDumpReader.Read7ZipStream</mainClass>
+						</manifest>
+					</archive>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/main/java/us/elephanthunter/Wiki7ZipXmlDumpReader/Wiki7ZipXmlDumpReader/Read7ZipStream.java
+++ b/src/main/java/us/elephanthunter/Wiki7ZipXmlDumpReader/Wiki7ZipXmlDumpReader/Read7ZipStream.java
@@ -1,4 +1,4 @@
-package us.elephanthunter;
+package us.elephanthunter.Wiki7ZipXmlDumpReader.Wiki7ZipXmlDumpReader;
 
 import org.apache.commons.compress.archivers.sevenz.SevenZArchiveEntry;
 import org.apache.commons.compress.archivers.sevenz.SevenZFile;

--- a/src/main/java/us/elephanthunter/Wiki7ZipXmlDumpReader/Wiki7ZipXmlDumpReader/SevenZFileInputStream.java
+++ b/src/main/java/us/elephanthunter/Wiki7ZipXmlDumpReader/Wiki7ZipXmlDumpReader/SevenZFileInputStream.java
@@ -1,4 +1,4 @@
-package us.elephanthunter;
+package us.elephanthunter.Wiki7ZipXmlDumpReader.Wiki7ZipXmlDumpReader;
 
 import java.io.IOException;
 import java.io.InputStream;


### PR DESCRIPTION
I managed to run the dump reader after just running `maven install`, i.e.:

```
$ mvn install
$ java -jar target/Wiki7ZipXmlDumpReader-0.0.1.jar
```
