### PR TITLE
Fix dependencies and genericize

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,11 @@
 			<artifactId>commons-compress</artifactId>
 			<version>1.12</version>
 		</dependency>
+		<dependency>
+			<groupId>org.tukaani</groupId>
+			<artifactId>xz</artifactId>
+			<version>1.5</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/src/main/java/us/elephanthunter/Wiki7ZipXmlDumpReader/Wiki7ZipXmlDumpReader/Read7ZipStream.java
+++ b/src/main/java/us/elephanthunter/Wiki7ZipXmlDumpReader/Wiki7ZipXmlDumpReader/Read7ZipStream.java
@@ -62,12 +62,31 @@ public class Read7ZipStream {
     }
 
     public static void main(String[] args) {
+        if(args.length < 1) {
+          System.err.println("Must provide a valid file path as the first parameter; no argument given.");
+          System.exit(1);
+        }
+        if(args[0].length() < 1) {
+          System.err.println("Must provide a valid file path as the first parameter; empty argument given.");
+          System.exit(1);
+        }
+        // Example files:
+        // enwiki-20160501-pages-meta-history5.xml-p000564697p000565313.7z
+        // enwiki-20160501-pages-meta-history27.xml-p042663462p043423161.7z
         try {
-            // Small file
-            SevenZFile sevenZFile = new SevenZFile(new File("/Users/elephanthunter/Source/7Zip Stream Reader/files/enwiki-20160501-pages-meta-history5.xml-p000564697p000565313.7z"));
+            File zFile = new File(args[0]);
+            if( ! zFile.exists()) {
+                System.err.println("The file specified by the first parameter must exist, but does not.");
+                System.exit(1);
+            }
 
-            // Large file
-            //SevenZFile sevenZFile = new SevenZFile(new File("/Users/elephanthunter/Source/7Zip Stream Reader/files/enwiki-20160501-pages-meta-history27.xml-p042663462p043423161.7z"));
+            if( ! zFile.canRead()) {
+                System.err.println("The file specified by the first parameter must be readable, but can't be read.");
+                System.exit(1);
+            }
+
+            SevenZFile sevenZFile = new SevenZFile(zFile);
+
             final SevenZFileInputStream sevenZFileInputStream = new SevenZFileInputStream(sevenZFile);
 
             SevenZArchiveEntry tmpEntry = sevenZFile.getNextEntry();


### PR DESCRIPTION
@leebradley Please review.

We were missing a Maven dependency here: https://mvnrepository.com/artifact/org.tukaani/xz/1.5

This also moves the file to the first parameter instead of a hardcoded string, e.g.:
```
 java -Djdk.xml.totalEntitySizeLimit=0 -jar /where/i/put/the/Wiki7ZipXmlDumpReader/target/Wiki7ZipXmlDumpReader-0.0.1.jar /where/i/put/the/wikipedia/dump/enwiki-latest-pages-meta-history10.xml-p002336425p002435847.7z
```